### PR TITLE
feat: Add Website URL Import to Recipe Parser (issue #26)

### DIFF
--- a/src/app/api/recipe/website/route.ts
+++ b/src/app/api/recipe/website/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface WebsiteApiResponse {
+    success: boolean;
+    content?: string;
+    error?: string;
+}
+
+/**
+ * Validate if URL is properly formatted
+ */
+function isValidUrl(url: string): boolean {
+    try {
+        const urlObj = new URL(url.trim());
+        return urlObj.protocol === 'http:' || urlObj.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Clean HTML content for recipe parsing
+ */
+function cleanHtmlForRecipe(html: string): string {
+    // Remove script and style tags with their content
+    let cleaned = html
+        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+        .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+        .replace(/<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>/gi, '')
+        .replace(/<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>/gi, '')
+        .replace(/<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>/gi, '');
+
+    // Remove HTML tags but keep content
+    cleaned = cleaned.replace(/<[^>]*>/g, ' ');
+
+    // Decode HTML entities
+    cleaned = cleaned
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&mdash;/g, '—')
+        .replace(/&ndash;/g, '–');
+
+    // Clean up whitespace and common non-recipe content
+    return cleaned
+        .replace(/\s+/g, ' ')
+        .replace(/\n\s*\n/g, '\n')
+        .replace(/^[\s\n]+|[\s\n]+$/g, '')
+        .trim();
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const body = await request.json();
+        const { websiteUrl } = body;
+
+        if (!websiteUrl) {
+            return NextResponse.json(
+                { success: false, error: 'Website URL is required' },
+                { status: 400 }
+            );
+        }
+
+        // Validate URL format
+        if (!isValidUrl(websiteUrl)) {
+            return NextResponse.json(
+                { success: false, error: 'Invalid URL format' },
+                { status: 400 }
+            );
+        }
+
+        // Fetch webpage content
+        const response = await fetch(websiteUrl, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (compatible; RecipeBot/1.0; +https://instadish.com)',
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                'Accept-Language': 'en-US,en;q=0.5',
+                'Accept-Encoding': 'gzip, deflate'
+            },
+            timeout: 10000 // 10 second timeout
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { success: false, error: `Failed to fetch webpage: ${response.status} ${response.statusText}` },
+                { status: response.status }
+            );
+        }
+
+        const html = await response.text();
+
+        if (!html || html.trim().length === 0) {
+            return NextResponse.json(
+                { success: false, error: 'Webpage returned empty content' },
+                { status: 404 }
+            );
+        }
+
+        // Clean HTML for recipe parsing
+        const cleanedContent = cleanHtmlForRecipe(html);
+
+        if (cleanedContent.length < 50) {
+            return NextResponse.json(
+                { success: false, error: 'Insufficient content found on webpage' },
+                { status: 404 }
+            );
+        }
+
+        const apiResponse: WebsiteApiResponse = {
+            success: true,
+            content: cleanedContent
+        };
+
+        return NextResponse.json(apiResponse);
+
+    } catch (error) {
+        console.error('Website scraping API error:', error);
+
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+        // Handle specific error cases
+        if (errorMessage.includes('ENOTFOUND') || errorMessage.includes('DNS')) {
+            return NextResponse.json(
+                { success: false, error: 'Website not found or DNS resolution failed' },
+                { status: 404 }
+            );
+        }
+
+        if (errorMessage.includes('ECONNREFUSED')) {
+            return NextResponse.json(
+                { success: false, error: 'Connection refused by website' },
+                { status: 503 }
+            );
+        }
+
+        if (errorMessage.includes('timeout')) {
+            return NextResponse.json(
+                { success: false, error: 'Request timeout - website took too long to respond' },
+                { status: 408 }
+            );
+        }
+
+        return NextResponse.json(
+            { success: false, error: `Failed to scrape website: ${errorMessage}` },
+            { status: 500 }
+        );
+    }
+}

--- a/src/services/websiteRecipeService.ts
+++ b/src/services/websiteRecipeService.ts
@@ -1,0 +1,239 @@
+import { parseRecipeText, ParsedRecipe, ParsingResult } from './aiParsingService';
+
+export interface WebsiteRecipeResult {
+    success: boolean;
+    recipe?: ParsedRecipe;
+    content?: string;
+    error?: string;
+    url?: string;
+}
+
+/**
+ * Validate URL format
+ */
+export const isValidWebsiteUrl = (url: string): boolean => {
+    try {
+        const urlObj = new URL(url.trim());
+        return urlObj.protocol === 'http:' || urlObj.protocol === 'https:';
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Fetch website content via API
+ */
+const fetchWebsiteContent = async (websiteUrl: string): Promise<{ success: boolean; content?: string; error?: string }> => {
+    try {
+        const response = await fetch('/api/recipe/website', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ websiteUrl })
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            return {
+                success: false,
+                error: data.error || `HTTP ${response.status}`
+            };
+        }
+
+        return {
+            success: data.success,
+            content: data.content,
+            error: data.error
+        };
+
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Network error occurred'
+        };
+    }
+};
+
+/**
+ * Clean website content for recipe parsing
+ */
+export const cleanContentForRecipe = (content: string): string => {
+    return content
+        // Remove common non-recipe phrases
+        .replace(/\b(subscribe|newsletter|follow us|social media|advertisement|cookie policy|privacy policy)\b/gi, '')
+        // Remove excessive punctuation
+        .replace(/[.]{3,}/g, '...')
+        .replace(/[-]{3,}/g, '---')
+        // Clean up extra whitespace
+        .replace(/\s+/g, ' ')
+        .replace(/\n\s*\n/g, '\n')
+        .trim();
+};
+
+/**
+ * Extract recipe from website URL by fetching content and parsing with AI
+ */
+export const extractRecipeFromWebsite = async (websiteUrl: string): Promise<WebsiteRecipeResult> => {
+    // Validate website URL
+    if (!isValidWebsiteUrl(websiteUrl)) {
+        return {
+            success: false,
+            error: "Invalid website URL format"
+        };
+    }
+
+    try {
+        // Step 1: Fetch website content
+        const contentResult = await fetchWebsiteContent(websiteUrl);
+
+        if (!contentResult.success || !contentResult.content) {
+            return {
+                success: false,
+                error: contentResult.error || "Failed to fetch website content"
+            };
+        }
+
+        // Step 2: Clean content for recipe parsing
+        const cleanedContent = cleanContentForRecipe(contentResult.content);
+
+        if (cleanedContent.length < 100) {
+            return {
+                success: false,
+                error: "Website content too short or doesn't contain meaningful recipe content"
+            };
+        }
+
+        // Step 3: Parse content with AI to extract recipe
+        const parsingResult: ParsingResult = await parseRecipeText(cleanedContent);
+
+        if (!parsingResult.success || !parsingResult.data) {
+            return {
+                success: false,
+                content: cleanedContent,
+                error: parsingResult.error || "Failed to extract recipe from website content"
+            };
+        }
+
+        // Step 4: Return successful result
+        return {
+            success: true,
+            recipe: parsingResult.data,
+            content: cleanedContent,
+            url: websiteUrl
+        };
+
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error occurred"
+        };
+    }
+};
+
+/**
+ * Validate that website content contains recipe-like content
+ */
+export const validateRecipeContent = (content: string): { isValid: boolean; confidence: number; reasons: string[] } => {
+    const recipeKeywords = [
+        'recipe', 'ingredients', 'instructions', 'cook', 'bake', 'prepare',
+        'cup', 'tablespoon', 'teaspoon', 'tbsp', 'tsp', 'ounce', 'pound', 'gram',
+        'oven', 'heat', 'mix', 'stir', 'add', 'pour', 'chop', 'dice', 'slice',
+        'minute', 'hour', 'temperature', 'degrees', 'fahrenheit', 'celsius',
+        'flour', 'salt', 'pepper', 'oil', 'butter', 'onion', 'garlic',
+        'serve', 'dish', 'meal', 'servings', 'prep time', 'cook time'
+    ];
+
+    const lowerContent = content.toLowerCase();
+    const words = lowerContent.split(/\s+/);
+    const totalWords = words.length;
+
+    if (totalWords < 100) {
+        return {
+            isValid: false,
+            confidence: 0,
+            reasons: ['Content too short']
+        };
+    }
+
+    let keywordCount = 0;
+    const foundKeywords: string[] = [];
+
+    recipeKeywords.forEach(keyword => {
+        const regex = new RegExp(`\\b${keyword.replace(/\s+/g, '\\s+')}\\b`, 'gi');
+        const matches = lowerContent.match(regex);
+        if (matches) {
+            keywordCount += matches.length;
+            foundKeywords.push(keyword);
+        }
+    });
+
+    const keywordDensity = keywordCount / totalWords;
+    const uniqueKeywords = foundKeywords.length;
+
+    // Calculate confidence score
+    let confidence = 0;
+    const reasons: string[] = [];
+
+    // Keyword density check
+    if (keywordDensity >= 0.03) {
+        confidence += 0.4;
+        reasons.push('High recipe keyword density');
+    } else if (keywordDensity >= 0.015) {
+        confidence += 0.2;
+        reasons.push('Moderate recipe keyword density');
+    } else {
+        reasons.push('Low recipe keyword density');
+    }
+
+    // Unique keywords check
+    if (uniqueKeywords >= 15) {
+        confidence += 0.3;
+        reasons.push('Many recipe keywords found');
+    } else if (uniqueKeywords >= 8) {
+        confidence += 0.2;
+        reasons.push('Some recipe keywords found');
+    } else {
+        reasons.push('Few recipe keywords found');
+    }
+
+    // Length check
+    if (totalWords >= 500) {
+        confidence += 0.2;
+        reasons.push('Good content length');
+    } else if (totalWords >= 200) {
+        confidence += 0.1;
+        reasons.push('Adequate content length');
+    } else {
+        reasons.push('Short content');
+    }
+
+    // Recipe structure patterns
+    const structurePatterns = [
+        /ingredients?:?\s*\n/gi,
+        /instructions?:?\s*\n/gi,
+        /directions?:?\s*\n/gi,
+        /\b\d+\.\s/g, // numbered steps
+        /\b(step|first|then|next|after|finally)\b/gi,
+        /\b\d+\s*(cup|tablespoon|teaspoon|ounce|pound|gram)\b/gi
+    ];
+
+    let patternMatches = 0;
+    structurePatterns.forEach(pattern => {
+        if (lowerContent.match(pattern)) {
+            patternMatches++;
+        }
+    });
+
+    if (patternMatches >= 3) {
+        confidence += 0.1;
+        reasons.push('Contains recipe structure patterns');
+    }
+
+    return {
+        isValid: confidence >= 0.4,
+        confidence: Math.min(confidence, 1.0),
+        reasons
+    };
+};


### PR DESCRIPTION
## Summary
- ✅ Server API endpoint for webpage scraping
- ✅ Client service with URL validation  
- ✅ Website URL tab in RecipeParser UI
- ✅ Error handling for invalid/inaccessible pages
- ✅ Integration with existing AI parsing service
- ✅ Notion database saving support

## Implementation
Universal website recipe import using AI parsing - works with any recipe site without site-specific scrapers.

Closes #26